### PR TITLE
Add BondingRestriction config trait for staking pallet

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -566,6 +566,7 @@ impl pallet_staking::Config for Runtime {
 	type OnStakerSlash = NominationPools;
 	type WeightInfo = pallet_staking::weights::SubstrateWeight<Runtime>;
 	type BenchmarkingConfig = StakingBenchmarkingConfig;
+	type BondingRestriction = ();
 }
 
 parameter_types! {

--- a/frame/babe/src/mock.rs
+++ b/frame/babe/src/mock.rs
@@ -206,6 +206,7 @@ impl pallet_staking::Config for Test {
 	type OnStakerSlash = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
+	type BondingRestriction = ();
 }
 
 impl pallet_offences::Config for Test {

--- a/frame/grandpa/src/mock.rs
+++ b/frame/grandpa/src/mock.rs
@@ -210,6 +210,7 @@ impl pallet_staking::Config for Test {
 	type OnStakerSlash = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
+	type BondingRestriction = ();
 }
 
 impl pallet_offences::Config for Test {

--- a/frame/nomination-pools/benchmarking/src/mock.rs
+++ b/frame/nomination-pools/benchmarking/src/mock.rs
@@ -113,6 +113,7 @@ impl pallet_staking::Config for Runtime {
 	type OnStakerSlash = Pools;
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
+	type BondingRestriction = ();
 }
 
 parameter_types! {

--- a/frame/offences/benchmarking/src/mock.rs
+++ b/frame/offences/benchmarking/src/mock.rs
@@ -182,6 +182,7 @@ impl pallet_staking::Config for Test {
 	type OnStakerSlash = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
+	type BondingRestriction = ();
 }
 
 impl pallet_im_online::Config for Test {

--- a/frame/session/benchmarking/src/mock.rs
+++ b/frame/session/benchmarking/src/mock.rs
@@ -188,6 +188,7 @@ impl pallet_staking::Config for Test {
 	type OnStakerSlash = ();
 	type BenchmarkingConfig = pallet_staking::TestBenchmarkingConfig;
 	type WeightInfo = ();
+	type BondingRestriction = ();
 }
 
 impl crate::Config for Test {}

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -918,7 +918,7 @@ impl BenchmarkingConfig for TestBenchmarkingConfig {
 	type MaxNominators = frame_support::traits::ConstU32<100>;
 }
 
-/// Means for checking if there is any external restriction on bonding with a specific accounts
+/// Means for checking if there is any external restriction on bonding with a specific account
 ///
 /// Allows for parts of the runtime that might implement other forms fund locking to prevent
 /// incompatible locking on accounts which could lead to unsafe state.

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -927,7 +927,7 @@ pub trait BondingRestriction<AccountId> {
 	fn can_bond(stash: &AccountId, controller: &AccountId) -> bool;
 }
 
-// Default implementation when no external restrictions ex
+// No restrictions
 impl<AccountId> BondingRestriction<AccountId> for () {
 	fn can_bond(_stash: &AccountId, _controller: &AccountId) -> bool {
 		true

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -920,7 +920,7 @@ impl BenchmarkingConfig for TestBenchmarkingConfig {
 
 /// Means for checking if there is any external restriction on bonding with a specific account
 ///
-/// Allows for parts of the runtime that might implement other forms fund locking to prevent
+/// Allows for parts of the runtime that might implement other forms of fund locking to prevent
 /// incompatible locking on accounts which could lead to unsafe state.
 pub trait BondingRestriction<AccountId> {
 	/// Determine if bonding is allowed with stash and controller combination

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -921,15 +921,15 @@ impl BenchmarkingConfig for TestBenchmarkingConfig {
 /// Means for checking if there is any external restriction on bonding with a specific account
 ///
 /// Allows for parts of the runtime that might implement other forms of fund locking to prevent
-/// incompatible locking on accounts which could lead to unsafe state.
+/// incompatible locking on a stash account which could lead to unsafe state.
 pub trait BondingRestriction<AccountId> {
 	/// Determine if bonding is allowed with stash and controller combination
-	fn can_bond(stash: &AccountId, controller: &AccountId) -> bool;
+	fn can_bond(stash: &AccountId) -> bool;
 }
 
 // No restrictions
 impl<AccountId> BondingRestriction<AccountId> for () {
-	fn can_bond(_stash: &AccountId, _controller: &AccountId) -> bool {
+	fn can_bond(_stash: &AccountId) -> bool {
 		true
 	}
 }

--- a/frame/staking/src/lib.rs
+++ b/frame/staking/src/lib.rs
@@ -917,3 +917,19 @@ impl BenchmarkingConfig for TestBenchmarkingConfig {
 	type MaxValidators = frame_support::traits::ConstU32<100>;
 	type MaxNominators = frame_support::traits::ConstU32<100>;
 }
+
+/// Means for checking if there is any external restriction on bonding with a specific accounts
+///
+/// Allows for parts of the runtime that might implement other forms fund locking to prevent
+/// incompatible locking on accounts which could lead to unsafe state.
+pub trait BondingRestriction<AccountId> {
+	/// Determine if bonding is allowed with stash and controller combination
+	fn can_bond(stash: &AccountId, controller: &AccountId) -> bool;
+}
+
+// Default implementation when no external restrictions ex
+impl<AccountId> BondingRestriction<AccountId> for () {
+	fn can_bond(_stash: &AccountId, _controller: &AccountId) -> bool {
+		true
+	}
+}

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -892,9 +892,9 @@ pub(crate) fn balances(who: &AccountId) -> (Balance, Balance) {
 
 pub struct AccountRestricted555;
 
-// Restrict both stash and controller accounts
+// Restrict stash account
 impl BondingRestriction<AccountId> for AccountRestricted555 {
-	fn can_bond(stash: &AccountId, controller: &AccountId) -> bool {
-		!(*stash == RESTRICTED_ACCOUNT || *controller == RESTRICTED_ACCOUNT)
+	fn can_bond(stash: &AccountId) -> bool {
+		*stash != RESTRICTED_ACCOUNT
 	}
 }

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -41,6 +41,7 @@ use std::cell::RefCell;
 
 pub const INIT_TIMESTAMP: u64 = 30_000;
 pub const BLOCK_TIME: u64 = 1000;
+pub const RESTRICTED_ACCOUNT: AccountId = 55500;
 
 /// The AccountId alias in this test module.
 pub(crate) type AccountId = u64;
@@ -302,6 +303,7 @@ impl crate::pallet::pallet::Config for Test {
 	type OnStakerSlash = OnStakerSlashMock<Test>;
 	type BenchmarkingConfig = TestBenchmarkingConfig;
 	type WeightInfo = ();
+	type BondingRestriction = AccountRestricted555;
 }
 
 impl<LocalCall> frame_system::offchain::SendTransactionTypes<LocalCall> for Test
@@ -886,4 +888,12 @@ pub(crate) fn staking_events() -> Vec<crate::Event<Test>> {
 
 pub(crate) fn balances(who: &AccountId) -> (Balance, Balance) {
 	(Balances::free_balance(who), Balances::reserved_balance(who))
+}
+
+pub struct AccountRestricted555;
+
+impl BondingRestriction<AccountId> for AccountRestricted555 {
+	fn can_bond(stash: &AccountId, controller: &AccountId) -> bool {
+		!(*stash == RESTRICTED_ACCOUNT || *controller == RESTRICTED_ACCOUNT)
+	}
 }

--- a/frame/staking/src/mock.rs
+++ b/frame/staking/src/mock.rs
@@ -892,6 +892,7 @@ pub(crate) fn balances(who: &AccountId) -> (Balance, Balance) {
 
 pub struct AccountRestricted555;
 
+// Restrict both stash and controller accounts
 impl BondingRestriction<AccountId> for AccountRestricted555 {
 	fn can_bond(stash: &AccountId, controller: &AccountId) -> bool {
 		!(*stash == RESTRICTED_ACCOUNT || *controller == RESTRICTED_ACCOUNT)

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -708,7 +708,7 @@ pub mod pallet {
 		TooManyValidators,
 		/// Commission is too low. Must be at least `MinCommission`.
 		CommissionTooLow,
-		/// External restriction prevents bonding with given accounts
+		/// External restriction prevents bonding with given account
 		BondingRestricted,
 	}
 
@@ -793,7 +793,7 @@ pub mod pallet {
 				return Err(Error::<T>::AlreadyPaired.into())
 			}
 
-			if !T::BondingRestriction::can_bond(&stash, &controller) {
+			if !T::BondingRestriction::can_bond(&stash) {
 				return Err(Error::<T>::BondingRestricted.into())
 			}
 

--- a/frame/staking/src/pallet/mod.rs
+++ b/frame/staking/src/pallet/mod.rs
@@ -40,10 +40,10 @@ mod impls;
 pub use impls::*;
 
 use crate::{
-	slashing, weights::WeightInfo, ActiveEraInfo, BalanceOf, EraPayout, EraRewardPoints, Exposure,
-	Forcing, MaxUnlockingChunks, NegativeImbalanceOf, Nominations, PositiveImbalanceOf, Releases,
-	RewardDestination, SessionInterface, StakingLedger, UnappliedSlash, UnlockChunk,
-	ValidatorPrefs,
+	slashing, weights::WeightInfo, ActiveEraInfo, BalanceOf, BondingRestriction, EraPayout,
+	EraRewardPoints, Exposure, Forcing, MaxUnlockingChunks, NegativeImbalanceOf, Nominations,
+	PositiveImbalanceOf, Releases, RewardDestination, SessionInterface, StakingLedger,
+	UnappliedSlash, UnlockChunk, ValidatorPrefs,
 };
 
 const STAKING_ID: LockIdentifier = *b"staking ";
@@ -200,6 +200,9 @@ pub mod pallet {
 
 		/// Weight information for extrinsics in this pallet.
 		type WeightInfo: WeightInfo;
+
+		/// Interface for doing bonding restriction check
+		type BondingRestriction: BondingRestriction<Self::AccountId>;
 	}
 
 	#[pallet::type_value]
@@ -705,6 +708,8 @@ pub mod pallet {
 		TooManyValidators,
 		/// Commission is too low. Must be at least `MinCommission`.
 		CommissionTooLow,
+		/// External restriction prevents bonding with given accounts
+		BondingRestricted,
 	}
 
 	#[pallet::hooks]
@@ -786,6 +791,10 @@ pub mod pallet {
 
 			if <Ledger<T>>::contains_key(&controller) {
 				return Err(Error::<T>::AlreadyPaired.into())
+			}
+
+			if !T::BondingRestriction::can_bond(&stash, &controller) {
+				return Err(Error::<T>::BondingRestricted.into())
 			}
 
 			// Reject a bond which is considered to be _dust_.

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -20,7 +20,7 @@
 use super::{ConfigOp, Event, MaxUnlockingChunks, *};
 use frame_election_provider_support::{ElectionProvider, SortedListProvider, Support};
 use frame_support::{
-	assert_noop, assert_ok, assert_storage_noop, bounded_vec,
+	assert_err, assert_noop, assert_ok, assert_storage_noop, bounded_vec,
 	dispatch::WithPostDispatchInfo,
 	pallet_prelude::*,
 	traits::{Currency, Get, ReservableCurrency},
@@ -5140,4 +5140,28 @@ fn proportional_ledger_slash_works() {
 		LedgerSlashPerEra::get().1,
 		BTreeMap::from([(4, 0), (5, value_slashed), (6, 0), (7, 0)])
 	);
+}
+
+#[test]
+fn bond_restriction_works() {
+	ExtBuilder::default().build_and_execute(|| {
+		assert_err!(
+			Staking::bond(
+				Origin::signed(RESTRICTED_ACCOUNT),
+				1,
+				1000,
+				RewardDestination::Controller
+			),
+			Error::<Test>::BondingRestricted
+		);
+		assert_err!(
+			Staking::bond(
+				Origin::signed(1),
+				RESTRICTED_ACCOUNT,
+				1000,
+				RewardDestination::Controller
+			),
+			Error::<Test>::BondingRestricted
+		);
+	});
 }

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -5155,25 +5155,14 @@ fn bond_restriction_works() {
 			),
 			Error::<Test>::BondingRestricted
 		);
-		assert_err!(
-			Staking::bond(
-				Origin::signed(1),
-				RESTRICTED_ACCOUNT,
-				1000,
-				RewardDestination::Controller
-			),
-			Error::<Test>::BondingRestricted
-		);
 
 		// put some money in account that we'll use.
-		for i in RESTRICTED_ACCOUNT + 1..RESTRICTED_ACCOUNT + 2 {
-			let _ = Balances::make_free_balance_be(&i, 2000);
-		}
+		let _ = Balances::make_free_balance_be(&(RESTRICTED_ACCOUNT + 1), 2000);
 
-		// Using unrestricted accounts should not fail
+		// Using unrestricted account should not fail
 		assert_ok!(Staking::bond(
 			Origin::signed(RESTRICTED_ACCOUNT + 1),
-			RESTRICTED_ACCOUNT + 2,
+			1,
 			1000,
 			RewardDestination::Controller
 		));

--- a/frame/staking/src/tests.rs
+++ b/frame/staking/src/tests.rs
@@ -5145,6 +5145,7 @@ fn proportional_ledger_slash_works() {
 #[test]
 fn bond_restriction_works() {
 	ExtBuilder::default().build_and_execute(|| {
+		start_session(2);
 		assert_err!(
 			Staking::bond(
 				Origin::signed(RESTRICTED_ACCOUNT),
@@ -5163,5 +5164,18 @@ fn bond_restriction_works() {
 			),
 			Error::<Test>::BondingRestricted
 		);
+
+		// put some money in account that we'll use.
+		for i in RESTRICTED_ACCOUNT + 1..RESTRICTED_ACCOUNT + 2 {
+			let _ = Balances::make_free_balance_be(&i, 2000);
+		}
+
+		// Using unrestricted accounts should not fail
+		assert_ok!(Staking::bond(
+			Origin::signed(RESTRICTED_ACCOUNT + 1),
+			RESTRICTED_ACCOUNT + 2,
+			1000,
+			RewardDestination::Controller
+		));
 	});
 }


### PR DESCRIPTION
BondingRestriction configuration trait on staking pallet to provide a means to add an external check before bonding a stash account, if other parts of the runtime might have an opinion about whether to allow it or not. 

Main usecase would be if there are other pallets that lock funds and we wish to avoid any conflicting locks.